### PR TITLE
尝试在bufferPool中增加了LFU页淘汰策略

### DIFF
--- a/src/main/java/com/microdb/config/DBConfig.java
+++ b/src/main/java/com/microdb/config/DBConfig.java
@@ -12,15 +12,19 @@ public class DBConfig {
      * 页的大小
      */
     private final int pageSizeInByte;
-
+    /**
+     * 基于LFU一次淘汰的页面个数
+     */
+    private final int evictCount;
     /**
      * 缓存池容量，单位：页
      */
     private final int bufferPoolCapacity;
 
-    public DBConfig(int pageSizeInByte, int bufferPoolCapacity) {
+    public DBConfig(int pageSizeInByte, int bufferPoolCapacity,int evictCount) {
         this.pageSizeInByte = pageSizeInByte;
         this.bufferPoolCapacity = bufferPoolCapacity;
+        this.evictCount = evictCount;
     }
 
     public int getPageSizeInByte() {
@@ -29,5 +33,8 @@ public class DBConfig {
 
     public int getBufferPoolCapacity() {
         return bufferPoolCapacity;
+    }
+    public int getEvictCount(){
+        return evictCount;
     }
 }

--- a/src/main/java/com/microdb/config/PropertiesConfigParser.java
+++ b/src/main/java/com/microdb/config/PropertiesConfigParser.java
@@ -25,10 +25,11 @@ public class PropertiesConfigParser {
             props.load(in);
             int pageSize = Integer.parseInt(props.getProperty("page_size", "4096"));
             int bufferPoolCapacity = Integer.parseInt(props.getProperty("buffer_pool_capacity", "100"));
+            int evictCount = Integer.parseInt(props.getProperty("evict_count", "10"));
             // load 文本
             // String text = load(filePath);
             // 文本parse，创建config
-            return new DBConfig(pageSize, bufferPoolCapacity);
+            return new DBConfig(pageSize, bufferPoolCapacity,evictCount);
         } catch (Exception e) {
             throw new ParseException("配置解析失败", e);
         }

--- a/src/main/java/com/microdb/model/page/Page.java
+++ b/src/main/java/com/microdb/model/page/Page.java
@@ -3,6 +3,7 @@ package com.microdb.model.page;
 import com.microdb.transaction.TransactionID;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Page 抽象接口
@@ -14,7 +15,10 @@ import java.io.IOException;
 public interface Page {
 
     PageID getPageID();
-
+    /**
+     * 获得页面访问频率
+     */
+    AtomicLong getAccessFrequency();
     /**
      * 序列化page数据
      */

--- a/src/main/java/com/microdb/model/page/bptree/BPTreeInternalPage.java
+++ b/src/main/java/com/microdb/model/page/bptree/BPTreeInternalPage.java
@@ -297,7 +297,7 @@ public class BPTreeInternalPage extends BPTreePage implements Serializable {
 
         // 第一个节点特殊处理
         if (getExistCount() == 0) {
-            setEntry(entry, 0);
+             setEntry(entry, 0);
             return;
         }
 

--- a/src/main/java/com/microdb/model/page/bptree/BPTreePage.java
+++ b/src/main/java/com/microdb/model/page/bptree/BPTreePage.java
@@ -8,6 +8,7 @@ import com.microdb.model.table.TableDesc;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * b+树各类页的公共属性、方法
@@ -21,8 +22,11 @@ public abstract class BPTreePage extends DirtyPage implements Page, Serializable
     /**
      * 页ID
      */
-    protected BPTreePageID pageID;
-
+    protected BPTreePageID  pageID;
+    /**
+     * 页在内存中的访问频率
+     */
+    protected AtomicLong accessFrequency=new AtomicLong(0);
     /**
      * 父节点pageNo,可能是internal节点或者是rootPtr节点
      */
@@ -42,6 +46,10 @@ public abstract class BPTreePage extends DirtyPage implements Page, Serializable
      * 原始页数据
      */
     protected byte[] beforePageData;
+    @Override
+    public AtomicLong getAccessFrequency() {
+        return accessFrequency;
+    }
 
     @Override
     public BPTreePageID getPageID() {

--- a/src/main/java/com/microdb/model/page/heap/HeapPage.java
+++ b/src/main/java/com/microdb/model/page/heap/HeapPage.java
@@ -13,6 +13,7 @@ import com.microdb.model.row.RowID;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 页，读写磁盘文件数据时以page为基本单位
@@ -27,6 +28,10 @@ public class HeapPage extends DirtyPage implements Page, Serializable {
      * page 编号
      */
     private PageID pageID;
+    /**
+     * 页在内存中的访问频率
+     */
+    protected AtomicLong accessFrequency=new AtomicLong(0);
     /**
      * 行数据数组
      */
@@ -61,6 +66,10 @@ public class HeapPage extends DirtyPage implements Page, Serializable {
 
         // 保留页原始数据
         saveBeforePage();
+    }
+    @Override
+    public AtomicLong getAccessFrequency() {
+        return accessFrequency;
     }
 
     @Override

--- a/src/main/java/com/microdb/model/table/tablefile/HeapTableFile.java
+++ b/src/main/java/com/microdb/model/table/tablefile/HeapTableFile.java
@@ -115,6 +115,8 @@ public class HeapTableFile implements TableFile {
             availablePage = new HeapPage(pageID, HeapPage.createEmptyPageData());
             writePageToDisk(availablePage);
             availablePage = (HeapPage) DataBase.getBufferPool().getPage(pageID);
+            //抵消insert时由于getPage增加的访问次数。
+            availablePage.getAccessFrequency().decrementAndGet();
         }
         availablePage.insertRow(row);
         Connection.cacheDirtyPage(availablePage);
@@ -137,6 +139,8 @@ public class HeapTableFile implements TableFile {
         for (int pageNo = 0; pageNo < existPageCount; pageNo++) {
             PageID pageID = new HeapPageID(this.getTableId(), pageNo);
             Page pg = DataBase.getBufferPool().getPage(pageID);
+            //抵消insert时每次遍历都增加一次访问。
+            pg.getAccessFrequency().decrementAndGet();
             if (pg.hasEmptySlot()) {
                 return pg;
             }

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -2,3 +2,5 @@
 page_size = 4096
 
 buffer_pool_capacity = 100
+
+evict_count = 10

--- a/src/test/java/system/LFUTest.java
+++ b/src/test/java/system/LFUTest.java
@@ -1,0 +1,112 @@
+package system;
+
+import base.TestBase;
+import com.microdb.bufferpool.BufferPool;
+import com.microdb.connection.Connection;
+import com.microdb.model.DataBase;
+import com.microdb.model.field.FieldType;
+import com.microdb.model.field.IntField;
+import com.microdb.model.page.Page;
+import com.microdb.model.page.PageID;
+import com.microdb.model.page.heap.HeapPageID;
+import com.microdb.model.row.Row;
+import com.microdb.model.table.DbTable;
+import com.microdb.model.table.TableDesc;
+import com.microdb.model.table.tablefile.HeapTableFile;
+import com.microdb.transaction.Lock;
+import com.microdb.transaction.Transaction;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class LFUTest extends TestBase {
+    public DataBase dataBase;
+    private BufferPool bufferPool;
+
+    /**
+     * LFU测试模块
+     * 该测试的config配置为
+     * page_size = 20 一页20字节
+     * evict_count = 10 LFU淘汰访问频率最低的10个页
+     * buffer_pool_capacity = 15 缓存中存储15个页
+     */
+    @Before
+    public void initDataBase() {
+        DataBase dataBase = DataBase.getInstance();
+        // 创建数据库文件
+        String fileName = UUID.randomUUID().toString();
+        List<TableDesc.Attribute> attributes = Arrays.asList(new TableDesc.Attribute("f1", FieldType.INT));
+        TableDesc tableDesc = new TableDesc(attributes);
+        File file = new File(fileName);
+        file.deleteOnExit();
+        HeapTableFile tableFile = new HeapTableFile(file, tableDesc);
+
+        // tableDesc
+        dataBase.addTable(tableFile, "t_person", tableDesc);
+
+        this.dataBase = dataBase;
+        this.bufferPool = DataBase.getBufferPool();
+
+    }
+
+    /**
+     * t_person 表只有一个int类型字段 一行内容占据5字节（1字节的slot+4字节的int变量）
+     */
+    @Test
+    public void insertRowTest() throws IOException {
+        DbTable tablePerson = this.dataBase.getDbTableByName("t_person");
+        Transaction transaction = new Transaction(Lock.LockType.XLock);
+        transaction.start();
+        Connection.passingTransaction(transaction);
+
+        // 创造80行内容，每行内容5字节，一页存储20/5=4行内容，一共有20页
+        for (int i = 0; i < 4*20; i++) {
+            Row row = new Row(tablePerson.getTableDesc());
+            row.setField(0, new IntField(i));
+            //插入并不计入访问频率
+            bufferPool.insertRow(row, "t_person");
+        }
+        ConcurrentHashMap<PageID, Page> pool = bufferPool.getPool();
+        //产生了20页，根据插入的先后顺序验证第19~5号页现在在内存中。
+        Set<Integer> set =new TreeSet<>();
+        Set<Integer> set2 =new TreeSet<>();
+        for (int i = 19; i >= 5; i--) {
+            set.add(i);
+        }
+        for (Page page : pool.values()) {
+            set2.add(page.getPageID().getPageNo());
+        }
+        Assert.assertEquals(set, set2);
+        //手动通过bufferPool进行访问，19号页访问0次，18号页访问1次...，0号页访问19次
+        for(int j=19; j>=0; j--) {
+            for (int i = 0; i < 19-j; i++) {
+                PageID pageID = new HeapPageID(tablePerson.getTableId(), j);
+                bufferPool.getPage(pageID);
+            }
+        }
+        //此时bufferPool中应该是访问频率最高的10个页（访问4号页时将19-10号页淘汰出缓存，因此剩余15-10+5=10个页面），0-9号页，访问频率从19-10次
+        pool = bufferPool.getPool();
+        Set<Page> set3 =new TreeSet<>(new Comparator<Page>() {
+            @Override
+            public int compare(Page o1, Page o2) {
+                return Integer.compare(o1.getPageID().getPageNo(), o2.getPageID().getPageNo());
+            }
+        });
+        set3.addAll(pool.values());int i=0;
+        for (Page page : set3) {
+            Assert.assertEquals(page.getPageID().getPageNo(), i);
+            Assert.assertEquals(page.getAccessFrequency().intValue(), 19-i);
+            i++;
+        }
+        transaction.commit();
+
+    }
+
+
+}

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -1,4 +1,4 @@
 
-page_size = 4096
+page_size = 20
 
-buffer_pool_capacity = 100
+buffer_pool_capacity = 15


### PR DESCRIPTION
主要修改：
1.在BufferPool类中增加静态内部类FixedSizeMinHeap，这是一个大根堆，方便实现频率最小的heapSize个页面的获取
2.在BufferPool中增加evictPagesByFrequency函数，以替代原来全页淘汰的evictPages函数
3.在BufferPool的getPage()函数中加入页面访问频率的增加操作
4.在HeapPage和BPTreePage中增加AtomicLong类型的成员变量，Page接口中增加getAccessFrequency()函数，以计算页的访问频率
4.增加LFUTest测试类，进行基于HeapPageFile的LFU页替换策略测试